### PR TITLE
Logging is removed from dcs.log as much as possible

### DIFF
--- a/Hooks/SharkPlanner.lua
+++ b/Hooks/SharkPlanner.lua
@@ -1,11 +1,12 @@
+package.path = package.path .. lfs.writedir() .. "Scripts\\?\\init.lua;"
+local Logging = require("SharkPlanner.Utils.Logging")
 
 local function loadSharkPlanner()
   local lfs = require("lfs")
-  package.path = package.path .. lfs.writedir() .. "Scripts\\?\\init.lua;"
   local SharkPlanner = require("SharkPlanner")
 end
 
 local status, err = pcall(loadSharkPlanner)
 if not status then
-  net.log("[SharkPlanner] load error: " .. tostring(err))
+  Logging.error("Load error: "..tostring(err))
 end


### PR DESCRIPTION
Since the GUI actions are triggered from UI C code and therefore the environment, and handling with pcall it is not possible to eliminate the logging into dcs.log when error occurs within the UI invocation.

However, the entry itself should continue in case of errors.